### PR TITLE
Fix Main.vi path and wording in gplugindata

### DIFF
--- a/Source/InstrumentStudio G Plugin/IS LabVIEW service host/LabVIEW MF.gplugindata
+++ b/Source/InstrumentStudio G Plugin/IS LabVIEW service host/LabVIEW MF.gplugindata
@@ -3,10 +3,10 @@
 	<Plugins>
 		<PluginData 
 			UniqueName="National Instruments|LabVIEW MF"
-			DisplayName="Measurement Framework"
-			PanelType="MF"
-			GroupName="MF"
-			VIPath="LabVIEW MF\Main.vi"
+			GroupName="Measurement Framework"
+			PanelType="LabVIEW Measurement UIs"
+			DisplayName="Host for LabVIEW Measurement UIs"
+			VIPath="Main.vi"
 			SupportedPanelSizes="Large"
 			DebuggingEnabled="false"
 			ReentrantExecutionEnabled="false"


### PR DESCRIPTION
### What does this Pull Request accomplish?

Jason Reding asked me to move the `.gplugindata` file into the `Addons/LabVIEW MF` directory instead of directly under `Addons`. When I did that, I forgot to update the path to `Main.vi`.

While testing, I noticed the MFs in the panel. Since it could mean other things we don't wish to imply, I worked with Ryan Friedman on new phrasing for those.

### Why should this Pull Request be merged?

- The plugin won't load without the fixed path
- MF is a bad description for our panels.

### What testing has been done?
![image](https://user-images.githubusercontent.com/48842985/170788422-511e979e-015d-4bb2-8a45-5ac2c257f906.png)


