### PR TITLE
Add vipb file for installation of Pin Map client library

### DIFF
--- a/Source/Pin Map Client_lv/build spec/Pin Map Client.vipb
+++ b/Source/Pin Map Client_lv/build spec/Pin Map Client.vipb
@@ -1,6 +1,6 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-03 16:34:30" Creator="navin" Comments="" ID="d74897e1fc27e54b692e7364cc667dce">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-03 16:37:22" Creator="navin" Comments="" ID="672caff4ea09c46e536597174255c68a">
   <Library_General_Settings>
-    <Package_File_Name>NI_lib_Session_Management_Client</Package_File_Name>
+    <Package_File_Name>NI_lib_Pin_Map_Client</Package_File_Name>
     <Library_Version>0.11.5.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\MeasurementLink Pin Map Client</Library_Source_Folder>


### PR DESCRIPTION
### What does this Pull Request accomplish?

Adds a .vipb (thus a means to build a .vip) for the Pin Map Client library.

### Why should this Pull Request be merged?

Usage of the Pin Map service - along with Session Management - enriches programmatic capabilities of pin-aware measurements in the MeasurementLink ecosystem, thus we wish to provide a library interface.

### What testing has been done?

1. Built VIP successfully
2. Inspected VIPM UI; all version numbers, descriptive strings, etc. were as expected.
3. Installed pin map client library; verified library was installed to proper location within vi.lib.
4. Exercised pin map G test for running the QueryPins request against the installed client library with the Pin Map service running.  It ran successfully.

### Additional note
- I used `Session Management.vipb` as a starting point and just modified as appropriate. A side-by-side comparison of the two produced expected differences.