### PR TITLE
Update packages to version 0.12.0 for next release

### DIFF
--- a/Source/Discovery Client_lv/build spec/Discovery Client.vipb
+++ b/Source/Discovery Client_lv/build spec/Discovery Client.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2022-12-16 15:35:11" Creator="navin" Comments="" ID="d35eec3d5ec47531a351fd687e5dbb14">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-19 13:45:25" Creator="navin" Comments="" ID="6d133cdf14245bc188a6487f188ce5de">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_Discovery_Client</Package_File_Name>
-    <Library_Version>0.11.5.2</Library_Version>
+    <Library_Version>0.12.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\MeasurementLink Discovery Client</Library_Source_Folder>
     <Library_Output_Folder>..\build</Library_Output_Folder>
@@ -172,7 +172,6 @@
       <close_labview_before_install>false</close_labview_before_install>
       <restart_labview_after_install>false</restart_labview_after_install>
       <skip_mass_compile_after_install>false</skip_mass_compile_after_install>
-      <install_into_global_environment>false</install_into_global_environment>
     </LabVIEW>
     <VI_Docs>
       <Edit_VI_Description>false</Edit_VI_Description>

--- a/Source/Measurement Service Scripting/build spec/LabVIEW Measurement Service Editor.vipb
+++ b/Source/Measurement Service Scripting/build spec/LabVIEW Measurement Service Editor.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-07 13:51:59" Modified_Date="2022-12-16 15:37:45" Creator="navin" Comments="" ID="2f59c285d824098a02ce6516c5339fd6">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-07 13:51:59" Modified_Date="2023-01-19 13:57:19" Creator="navin" Comments="" ID="ecd2d58daf0185283667efe6e03765a7">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_LabVIEW_MeasurementLink_Editor</Package_File_Name>
-    <Library_Version>0.11.5.2</Library_Version>
+    <Library_Version>0.12.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\build</Library_Output_Folder>
@@ -183,7 +183,6 @@
       <close_labview_before_install>false</close_labview_before_install>
       <restart_labview_after_install>false</restart_labview_after_install>
       <skip_mass_compile_after_install>false</skip_mass_compile_after_install>
-      <install_into_global_environment>false</install_into_global_environment>
     </LabVIEW>
     <VI_Docs>
       <Edit_VI_Description>false</Edit_VI_Description>

--- a/Source/Measurement Service Template_lv/build spec/LabVIEW Measurement Service Template.vipb
+++ b/Source/Measurement Service Template_lv/build spec/LabVIEW Measurement Service Template.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-07 13:16:14" Modified_Date="2022-12-20 10:18:18" Creator="navin" Comments="" ID="dd6fd73e1e19d5f92496a7602a807e09">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-07 13:16:14" Modified_Date="2023-01-19 13:52:44" Creator="navin" Comments="" ID="eea295e125b3c1f7034d0328fa0e8220">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_LabVIEW_MeasurementLink_Template</Package_File_Name>
-    <Library_Version>0.11.5.2</Library_Version>
+    <Library_Version>0.12.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\build</Library_Output_Folder>

--- a/Source/Pin Map Client_lv/build spec/Pin Map Client.vipb
+++ b/Source/Pin Map Client_lv/build spec/Pin Map Client.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-03 16:37:22" Creator="navin" Comments="" ID="672caff4ea09c46e536597174255c68a">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-19 13:59:15" Creator="navin" Comments="" ID="494339bb89379aff5104917ffb69f7f4">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_Pin_Map_Client</Package_File_Name>
-    <Library_Version>0.11.5.2</Library_Version>
+    <Library_Version>0.12.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\MeasurementLink Pin Map Client</Library_Source_Folder>
     <Library_Output_Folder>..\build</Library_Output_Folder>

--- a/Source/Session Management Client_lv/build spec/Session Management Client.vipb
+++ b/Source/Session Management Client_lv/build spec/Session Management Client.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2022-12-21 14:06:03" Creator="navin" Comments="" ID="9830e9ec4e2756ca2947668fe7539951">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2021-11-01 10:28:06" Modified_Date="2023-01-19 14:01:48" Creator="navin" Comments="" ID="1c3ddc857bc711485772b10edaff8ac6">
   <Library_General_Settings>
     <Package_File_Name>NI_lib_Session_Management_Client</Package_File_Name>
-    <Library_Version>0.11.5.2</Library_Version>
+    <Library_Version>0.12.0.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\MeasurementLink Session Management Client</Library_Source_Folder>
     <Library_Output_Folder>..\build</Library_Output_Folder>
@@ -172,7 +172,6 @@
       <close_labview_before_install>false</close_labview_before_install>
       <restart_labview_after_install>false</restart_labview_after_install>
       <skip_mass_compile_after_install>false</skip_mass_compile_after_install>
-      <install_into_global_environment>false</install_into_global_environment>
     </LabVIEW>
     <VI_Docs>
       <Edit_VI_Description>false</Edit_VI_Description>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Assigns vipb package versions to 0.12.0 (.. having built the 0.12.0.1 packages, thus packages automatically marked with 0.12.0.2)

### Why should this Pull Request be merged?

This is standard procedure for releasing new versions of this repo

### What testing has been done?

Having installed all updated packages:
- Verified that basic measurement generates, is runnable in its default state, and enumerates & functions in InStudio
- Verified that the build spec works out-of-the-box and creates a measurement exe that enumerates & functions in InStudio
- Made various modifications to the default measurement; it responded appropriately in Instudio
  - Changed logic in `Measurement Logic.vi`
  - Injected an error on the error rail of `Measurement Logic.vi`
- Successfully ran NI-DMM example in LV / InStudio (although it is currently built against an older template, this example still works)
- Ran G Autotests against installed VIs, all passed