### PR TITLE
Update packages for 0.12.2 release

### DIFF
--- a/Source/Build Specs/MeasurementLink Generator.vipb
+++ b/Source/Build Specs/MeasurementLink Generator.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-01-27 11:34:32" Creator="lvadmin" Comments="" ID="664982c683a8ff31ab35301cdf1798a6">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-02-10 08:42:07" Creator="lvadmin" Comments="" ID="2322484e994c8dc40d9f9bbc6b1cd763">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Generator</Package_File_Name>
-    <Library_Version>0.12.1.2</Library_Version>
+    <Library_Version>0.12.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\Generator</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>
@@ -17,8 +17,8 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=0.5.2.2</Additional_External_Dependencies>
-      <Additional_External_Dependencies>ni_measurementlink_service &gt;=0.12.1.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_measurementlink_service &gt;=0.12.2.1</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI/>

--- a/Source/Build Specs/MeasurementLink Service.vipb
+++ b/Source/Build Specs/MeasurementLink Service.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-01-27 11:26:09" Creator="lvadmin" Comments="" ID="927eab5beba239cfadb3652b13dfedef">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-02-10 08:33:31" Creator="lvadmin" Comments="" ID="f98eebc92f6079e28c4fee90236b6c20">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Service</Package_File_Name>
-    <Library_Version>0.12.1.2</Library_Version>
+    <Library_Version>0.12.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\Runtime</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>
@@ -17,7 +17,7 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=0.5.2.2</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.1</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI/>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Updates vipb packages for 0.12.2 release (.. having built the 0.12.2.1 packages, thus vipbs automatically marked with 0.12.2.2)

### Why should this Pull Request be merged?

This release pulls in latest grpc-labview dependencies (v1.0.0.1), thus is inches us closer to a 1.0 release of this repo.

### What testing has been done?

Having installed updated packages:
- Verified that basic measurement generates, is runnable in its default state, and enumerates & functions in InStudio
- Verified that the build spec works out-of-the-box and creates a measurement exe that enumerates & functions in InStudio
- Made various modifications to the default measurement; it responded appropriately in Instudio
  - Changed logic in `Measurement Logic.vi`
  - Injected an error on the error rail of `Measurement Logic.vi`
- Successfully ran cancellable measurement example, functions in InStudio
- Successfully ran all G tests against installed VIP content; all passed