### PR TITLE
Limit installation to 64 bit Windows machines with LabVIEW 64 bit

### DIFF
--- a/Source/Build Specs/MeasurementLink Generator.vipb
+++ b/Source/Build Specs/MeasurementLink Generator.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-03-24 11:51:40" Creator="lvadmin" Comments="" ID="b71b345a684a472d84127809b0d004d5">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-05-08 10:03:04" Creator="lvadmin" Comments="" ID="f56b82beb956d0a91534b8b36d44946f">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Generator</Package_File_Name>
     <Library_Version>1.0.1.2</Library_Version>
@@ -180,14 +180,14 @@
       <Windows_7>true</Windows_7>
       <Windows_Vista>true</Windows_Vista>
       <Windows_XP>true</Windows_XP>
-      <Mac_OS>true</Mac_OS>
-      <Linux>true</Linux>
+      <Mac_OS>false</Mac_OS>
+      <Linux>false</Linux>
       <Built_LV_Version>false</Built_LV_Version>
       <Built_LV_Version_or_greater>true</Built_LV_Version_or_greater>
       <Windows_8>true</Windows_8>
-      <OS_32-Bit>true</OS_32-Bit>
+      <OS_32-Bit>false</OS_32-Bit>
       <OS_64-Bit>true</OS_64-Bit>
-      <LV_32-Bit>true</LV_32-Bit>
+      <LV_32-Bit>false</LV_32-Bit>
       <LV_64-Bit>true</LV_64-Bit>
     </Install_Requirements>
     <LabVIEW>

--- a/Source/Build Specs/MeasurementLink Service.vipb
+++ b/Source/Build Specs/MeasurementLink Service.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-03-24 11:46:35" Creator="lvadmin" Comments="" ID="93ec062f75cf5ead9934586d3d192377">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-05-08 10:01:50" Creator="lvadmin" Comments="" ID="dfe88f50427506fc2ad92ab81aecd4b9">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Service</Package_File_Name>
     <Library_Version>1.0.1.2</Library_Version>
@@ -180,14 +180,14 @@
       <Windows_7>true</Windows_7>
       <Windows_Vista>true</Windows_Vista>
       <Windows_XP>true</Windows_XP>
-      <Mac_OS>true</Mac_OS>
-      <Linux>true</Linux>
+      <Mac_OS>false</Mac_OS>
+      <Linux>false</Linux>
       <Built_LV_Version>false</Built_LV_Version>
       <Built_LV_Version_or_greater>true</Built_LV_Version_or_greater>
       <Windows_8>true</Windows_8>
-      <OS_32-Bit>true</OS_32-Bit>
+      <OS_32-Bit>false</OS_32-Bit>
       <OS_64-Bit>true</OS_64-Bit>
-      <LV_32-Bit>true</LV_32-Bit>
+      <LV_32-Bit>false</LV_32-Bit>
       <LV_64-Bit>true</LV_64-Bit>
     </Install_Requirements>
     <LabVIEW>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We had an internal escalation about a Measurement UI.vi not loading. The issue turned out to be that the machine only had LabVIEW 32-bit. This PR limits installation of MeasurementLink to 64-bit Windows machines that have LabVIEW 64-bit installed. This should prevent similar issues from happening in the future.

![image](https://user-images.githubusercontent.com/57813166/236860123-c6bdab40-1742-49c9-84be-88cd743c4e8f.png)


### Why should this Pull Request be merged?

This should prevent future escalations.

### What testing has been done?

I built the packages locally. Otherwise I am counting on VIPM to do what it promises.