### PR TITLE
Add pre-commit to prevent someone committing directly to main

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Stops accidental commits to master/main/develop. https://gist.github.com/stefansundin/9059706
+# Install:
+# cd path/to/git/repo
+# curl -fL -o .git/hooks/pre-commit https://gist.githubusercontent.com/stefansundin/9059706/raw/pre-commit
+# chmod +x .git/hooks/pre-commit
+
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+
+if [[ "$BRANCH" =~ ^(master|main|develop)$ ]]; then
+  >&2 echo "You are on branch $BRANCH. Are you sure you want to commit to this branch?"
+  >&2 echo "If so, commit with -n to bypass this pre-commit hook."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

Prevent accidental commit to main
