### PR TITLE
Disable result recording in Setup and Cleanup block steps

### DIFF
--- a/Source/Example Measurements/NI-DCPower Source DC Voltage/NIDCPowerSourceDCVoltage.seq
+++ b/Source/Example Measurements/NI-DCPower Source DC Voltage/NIDCPowerSourceDCVoltage.seq
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 (21.0.0.49156)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
+<teststandfileheader type='SequenceFile' fileversion='962' productname='TestStand' productversion='2021 SP1 (21.1.0.49154)' compatibleversion='21.0.0.0' buildversion='21.0.0.49156' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.ni.com/TestStand/21.0.0/SequenceFile">
 	<typelist>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='1'>
-			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Expression classname='ExprValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Expression>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='2'>
-			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeMenu classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<CanBeSubstepType classname='Bool'>
 						<value>false</value>
@@ -37,12 +37,12 @@
 			</StepTypeMenu>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='3'>
-			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
+			<StepTypeSubstepsArray classname='Objs' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4849688' valueflags='24'>
 				<value lbound='[0]' ubound='[]'/>
 			</StepTypeSubstepsArray>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='4'>
-			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_ArrayDimensions classname='ArrayDimensions' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LowerBounds classname='Nums'>
 						<value lbound='[0]' ubound='[]'/>
@@ -54,7 +54,7 @@
 			</NI_ArrayDimensions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='5'>
-			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_PropertyObjectType classname='PropertyObjectType' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ValueType classname='Num'>
 						<value>3</value>
@@ -88,7 +88,7 @@
 			</NI_PropertyObjectType>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='6'>
-			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CustomResult classname='CustomResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -148,7 +148,7 @@
 			</NI_CustomResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='7'>
-			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
+			<TEInf classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4456472' instanceoverrideflags='4456472' valueflags='24'>
 				<subprops>
 					<Id classname='Str' flagsforinstances='1' instanceoverrideflags='5046297'>
 						<value/>
@@ -423,7 +423,7 @@
 			</TEInf>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='8'>
-			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
+			<StepTypeNIData classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='24'>
 				<subprops>
 					<EditPanels classname='Strs'>
 						<value lbound='[0]' ubound='[]'/>
@@ -432,7 +432,7 @@
 			</StepTypeNIData>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='9'>
-			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Error classname='Obj' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<extdata controllername='STRUCT' allowstructpassing='true' packingoption='8' exclude='false' type='0' arraystorage='0' strbuffersize='256' strstorage='0'/>
 				<extdata controllername='CLUST' allowclusterpassing='true' exclude='false' memberlabel=''/>
 				<extdata controllername='DNSTRUCT' allowstructpassing='true' exclude='false' membername=''/>
@@ -463,10 +463,10 @@
 			</Error>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='10'>
-			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.0.0.49156' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
+			<CommonResults classname='Obj' isroottypedef='true' typecategory='3' timestamp='1465572565' typeversion='3.1.0.100' typelastmodversion='21.1.0.49154' typeminprodversion='3.1.0.0' typeflags='33554432' flagsforinstances='4194304' valueflags='4194304'/>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='11'>
-			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<Substep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -891,7 +891,7 @@
 			</Substep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='12'>
-			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetParameterResult classname='DotNetParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -907,7 +907,7 @@
 			</NI_DotNetParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='13'>
-			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetParameter classname='DotNetParameter' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -974,7 +974,7 @@
 			</DotNetParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='14'>
-			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_DotNetCallResult classname='DotNetCallResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -990,7 +990,7 @@
 			</NI_DotNetCallResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='15'>
-			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetCall classname='DotNetCall' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ClassName classname='Str'>
 						<value/>
@@ -1091,12 +1091,12 @@
 			</DotNetCall>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='0'>
-			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436'>
+			<Path classname='PathValue' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436'>
 				<value/>
 			</Path>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='16'>
-			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<DotNetStepAdditions classname='DotNetModule' isroottypedef='true' typecategory='3' timestamp='1650061192' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Calls classname='Objs'>
 						<value lbound='[0]' ubound='[]'>
@@ -1241,7 +1241,7 @@
 			</DotNetStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='17'>
-			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<PostSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -1666,7 +1666,7 @@
 			</PostSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='18'>
-			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
+			<NoneStepAdditions classname='NoneModule' isroottypedef='true' typecategory='3' timestamp='1650060850' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'/>
 		</typedef>
 		<protected>E@=3DJC4100hYLECF=_K@0@mKCYo_1KN:&lt;Ta239hF9[gHbEVFDfRINZfQ01CkaUMk5=k`[c;[42MMF9aiNliecVfMFCLXi_`f2H7c\G\X50M=Z4S4aT2QI&gt;A^D:d1\PCI`L11RlV5bM5AIZTc9STI5Mkg&lt;bHlle[O=CL_KEgb?8RiVHS7QmPY@S4X^7I58A@kPaKcPWCOC1;DBf61lViY=]`28BC\B_mEf20ZJS@W@GDDRffLe\Ci;aKbN&gt;i5P_4ScVVBTjIIfn0j8l&lt;e6IcMbZHgCI;n8CRlR7&lt;YcK0@cY[8aDHj=GGkNK;C?KC?b=]mMejoc1gGol1&gt;hL6lf5fZ92?Ia@l1;QL024f^NSm2MhNlcFg_YR[l5kclo:einXehbR&gt;98[4?GC:CX[3hm\UMob2aIMT0eJmgI@\;njRK9]fIl_8f=d]n4bQcRXDEl&lt;o=@Yiik\3Md@?k1=0Joj&gt;?Je`&lt;RUd&lt;JYmeOnOgB3G@Ub\FoGFgIQmQli8nGH=QjKD9i`2nf41XEKj;oDB8iZU`@XP^KWoAKEbOf:ViVAl=_I37KJSec7Ea\nJ5]NZj\OnJF;ASQemRIDbbdglb\U&gt;H[O^bDHO?XMLaOoeVCf=a^CC`d8^TX2B</protected>
 		<protected>E@=3@J\4110h]L]Mg[cK3fBoj\Kifo1C[KY_3VgFm3_6n&gt;DfdTDgjaSF_LdVUJaY::FII@T:GB9LaYOo80OP^053LBBVb1G?:50k4;P1c\^`03ffoj9S72=AOm;a2oh?Na\lC7TUOXcNfaSdfIbVCC_ao20aN9bmo_&lt;R_S=&gt;KV;lhbmh89SY[:2UflXcmGIlnngoE]\\ad_6_gW8X9GAXJSPJYin&gt;C71=c74a79JN&lt;`GPK]_\&gt;2`h9IOC]VA5BU4AMW1Qc`j?lJ\aR4__&gt;R4SI_`[_mmnM33ONg`3P[g4N5aSF;ce]^eVffg6&gt;cIRLhI]7CjE^W[jW`kZkGEWHk1=RR;gTe:O[H;k[bAd7UCaTVXgjlho3Af&gt;?oIJdjMo&gt;3=o;aTo\ZZnG9_cgcO7mjV^k&gt;\:gkoOkSn1jkfm@MgLnb&lt;Amg;\Nmj8klk3llhhnW&gt;nn^GCW_fW_&gt;ji]:Va&gt;TNnNQdK5LolNX?M@\6jN2ddlIHh=MT1E^[o4Q7I54R=RlVg[S\KmOe9GM:Qeh9OnUhWTeC^ZM7SAGP1V=LZ4[i\cOmoH[RS6YBL2L\PAg][JQ&lt;Eo?8;D9Mk3M]&gt;N^6&gt;HgJ]KP^a&gt;cfBkkmZ33RdU`]jB_NIOShWL4oDlbn3lNOCL??R7GCmKaTDhekoi_En`9oJKe&lt;e1`lBjmjXJ&lt;^4_^_^&gt;?7O?nEE_WTY:VYEc]3^eJm^cdC7;LcK_]Ei&gt;b&lt;^`9HR6YcO&gt;l@Amg&gt;PLXQbSb^=?FXRUZd&lt;[n&lt;SGjgCQ`mhTl;7NUbgaRQBkXNY4iX5iAJX6C`gdG[d3d&gt;`Uj3DPMF7h71WBBLLR&gt;Tk9dZlFCYSi__fNBBT`C;A&gt;jeP2CdONN52i5^eBEIEI=8EMHBBe^G^1ohD6&gt;LRiJgM\IPYE8Wn`T9W@jf8iEfN:@L3&lt;Ha_l0CCE&lt;HOJjXBRll_NLReo_^K7CQWihL&lt;B1::YXdSaG&lt;XFnCP94dQXb;^6V07F&gt;TkPem&gt;4QI;?9JkF`g80:`G?AULFSY^XW;4XL^_D=GZV9VVODS^[=]dL]b=N;O[ib6]2aLATM7\AcX=JH&lt;\1j8_?I9_VUO]5;PKjdi^o&gt;Kn=FbmhAmF3EXh?dAPF?cWPU;NHFT9YBblF15fj0n]RK9&gt;d;@lD9HXLGTZOAa;gEd6:MElAPOkOoMom`hnaYko^ne_;PeC\`kMYOoCalP3DR_^NADNSV6R1Nk4f?=Lo;VQ&gt;7&gt;fR@=2j8C:;D@3fk&gt;^=YHE^PQ1fU&gt;TFoNH&gt;GnfRGNMNW`[okK`S56RJfM4Zmo^6E9ZYc&gt;FNEO3PO=T9eK0:bgljYdR7WooKS9eTjd@bcImNVZ8UXa:AC_F_WCj]4\6ST&lt;:ie_AbZFIL7UmlIne:BcTQ5T2U]O2goYWXRN5F8oeQT^`HXPD=2LV[h;ibbNNj1kU]lXlnX4ACO5aRA@TfHY77@P?L=_N@4^cJG;Wi2@3M5OQ:^@&gt;2K9_9W:4Vn1LGaRN@WL9AFFVg1oYHdi`54XIa5G[\i&gt;iPT4506XA7h2^c_T`3d[ARdFICaAS2RM:1KgT7B&gt;MhXVaI&lt;kA^@CX2aS^I:B&gt;=W&lt;U?l&lt;DWU&lt;Jd7^cKe2R]EdIBcBQZni_K1JPCEhV&gt;VH]FBZ&lt;5413k[U]MAFA`Ohma2g2NoU0@E;FI93Yi;RjnlScC;`glEaH^X@K[NY9Y1EUZc6V6\3?FKC0APU0^[aP:_GMI=eeWnJ&lt;6e2]@;AXaAE&lt;S[lhAb`XFjPP@dTXNYS=&lt;568je\`W3?@gn9HDaM84^&gt;SDl0&lt;Ba6YNKCeYZ\CUU?WGnR4=m^aN[KTlFG\?VZ[MC:3HfflAagl\jZUG@ScZW:2K\FU9TQa&lt;h;?iYb&lt;RJI66IEg&lt;WHgdkU:\KFIZG\BDU=9W&gt;:\:W7nM3NIjXT;2YV[@dDaY3bhOQY^af&lt;UVo:ZV^^@0d_M5ObRQ2PIHZ9bbbGm;4Z\KEfEYI=M];D@9j1kZ@2@FIkf9:\CYe5KnKANXH7R@eMc2M;Pl]PZG]@4h2Q7OY:=QFh@\Y6]E6X1bL6mjS76a`JS=H=XQReG6Djb7[c&lt;h@S5UCX4`ABLQ4:ZZ7=JF9JejC5\[T:meE5_[:`Qm=DfI0EDQLRH6o]LAPRXlbTgXSbnW7ZTN?N]lH02JKm;Z4hn&lt;A[89:C8lM5hC]Ab^\\WNK7JGS]XainLm:PWFF3EmC15\]YC\D;I6a&lt;NiIhd2GMIG`A9\[]T00fP:UXIXSHk2jI&gt;XFG&gt;I521bbKDA`Xb]h&gt;oAl&gt;IolbRB7j=i9_H89&lt;FR=U572U\LjNhnkeeemHDJJ\GHX\;J51M&lt;?QV2DneREAR3in6&lt;M75M_Re=Ci3gEOQ2VO`4P8_hfhSO\dZ7m]n\hlV6gSlSC@PoZSe8WUaY3d0_;Z=9H:I6Gf2PVG`mf8CC87@DBlT62^h6QFFhZF64BJ46@Dh&lt;T1=C]0_9J?073S@61ADIUT31&lt;mVE&lt;W?R@RBUJP`@;50X2Bh618KM^bf033T033D?NM@P`?0\dBA3A8AXF0]@KnP[5&lt;EDfUICcBF^EZT=:cWKBKYTDKXD=&lt;A:mkNB7LFDHC9b7nG57NFZ1]Ubo]8]0MN]YWJJ&gt;eS42I?===3_n_?J=384=Go8e^0mdmBiTjRaf;F@8M4_gCZSGQ3cUUnF6J_R9WJV0PNaTJDk&lt;RiWS6=&gt;Rf9EmM:WgL4LHg5oH[aMbbOlnI6b`9KZ^Z]oAdeH\@YgaV8ChHTKjEVA]a^YN&lt;;71CAbR\&lt;jAYI\\Y&lt;R\`1AOol`j1&gt;53?d8MV_@kAN_W4nIdKc0gRYHEo`]U?HWN?0&lt;?l2h:ZC\&gt;^D]Ug4FNZl123fNoZ7fLRB[_HR6O&gt;BaoomWl_8YS0Q\8;RB]@j=GIIe]J&lt;AT[;1I&lt;5ZJ\?Va5g?&gt;7hXgcbU4V=lT&gt;nV[28JKeQJ5QX4^WD3MfTBIBPKU57e&gt;[FRd&gt;_EeSHJhDa4hM9S9TUlOR=KWn]eAJ]W5VROh9ak`n5&lt;LV6L9d&lt;0`?fk]J8FW52OlL2i&lt;L1kO=mGBf9e:\`^[_J:F&gt;7o0_9mGc_`=KP@SW_^NU525JcQcEGhR8Da3gf4mJ?R6a2lLPKjL:TlfL8iHOKf:Mjeb\&gt;Xb3&gt;0kM@iNkaifYHDFNIKP\e^;bhg@V&lt;g0Za7F]R=JKPMgdg&gt;nYaMSb8MAV0o05XKjM5&lt;5^V=albT\&lt;868hhl^jHPRa0KcT4i[31chfOeGW&gt;;``&gt;&gt;I;B:YafYW&gt;jW_7D1&gt;9_X14U9VXJ5E_PA2ZPb&gt;n6eBLcN]SU4eSd&lt;IDGD4D5WHMlFCU0DeARScb:h\?EC1&gt;IBWead&gt;7F&gt;FeBea\oCS]jf@kE47ZHcB?TlP6_K[QC2@_N&gt;ilNn0VdgZE&gt;Z98hXCHa4bNUM16M74Q;DhldmcZ&gt;V?_TG1J?NI:F8&lt;aomhdPX5^AEe6BRYle4clf_gSb6D9LaD2h]ij8SAH@[`J@cb2G7ee@iZWl2A&gt;`Ga95FDhJo7Xo&gt;Zd3[jL&lt;DQ4OILX9a;0T\SUDWY:Bh&gt;WGNb:dHQ[S`[8:1L:F@&gt;H[49RQ6_3QV&lt;UT0oIITF^H_\X=:&lt;42`N``YjM75HWEd]5O`&lt;EX89FTP`^oN:QHgED5k:\CaYbA2GbD1;X5:N;?SoLhVhR`R_9lg3hU4n:I`2Gn:IjDHED]5i=2fcTklTK1H6k4HjK;HBM&gt;;c]9;i[MFD?WaY1O]oS293kLd9S3N6He?:_QKEcBGLOc:jB6H@fR]h]HGB5;:&lt;RE&lt;`3K4Ibi29dR;nU&lt;&lt;TKBRnTdK[ZTT6oiOVVXKgaP6&lt;lMTO_JC\0&lt;RY5NkR352&lt;FbcCB&lt;_3?0XjQ`BJP;OJR::8eHFb3&lt;;M\9FOC8T:MkD:Z;C=eb^0:AMSbSY_^Lc=SGbD5WDh@6j]PCDc@;\X1Nb\[`Z0W_Th5&lt;HD4CafYghb`T95Ko571]SZJDHF2eE&lt;7jViL_\8TQ@dFRo]`G[h3&gt;862l:2F[UU6dVbFjU?NI&gt;OHOk&gt;JNcFNU[mXi]iJ[neWQ\mWa]i[e?IkO^Mf]LHTP[G3?43M8g^Wh``lW3kBT7ADM6b_IUCIPO=C8g5@?9R3&lt;hilXNY7_&lt;THNN&lt;KMLm;eGM6_A6AUDB\c5Q;S2POniP9[mdEeIDnO7;T7Nia2nFN\L2XZIP?ZJKW\2cK0U5fb[dLn?[C&gt;YAMXfVFic02OQA\6LHEk0oBd0f;`kR1hImAUl:@I;^:oFJUF?mDgPlLokm]OIgenn9;n5[Oh3g7@W7OWBCk9X1mYDPF9AQ4LOGeM_D_WR?I7QRlVEmN_0QlA9^lO[HjnfngGjkHokO\A35=_4hVU^jKm;\?Y9^B=RkTG1I&lt;6nI`AQ_kJ;of[GmIi[g0]1\UG_FKUnX]ZcGmoI;NUdDFOolHn;NbMLkT`1GEo;j63N_8b_O`PQ[KRjb&lt;NDHW4;\lT[Ila;nMd`56_c\C25fJLUS;9fn@6[[SMIBBMFK\8d;ZIRSI;fJ5_cojWSIfcY2kNd1jkS0f9A3BNfk8W1m4H0gRbfA3J6Q726nmNm4PQYcWZ___NEf_FmmmOm40IZ1mf4PmS?H8k&gt;=J3g&lt;\1K6j;CNTGZ8kY61mk30RLUO`T`_H`Hg&lt;`\K67=HJ3g&lt;\3K6iGRVO9``_1H`L`\K6`f=371ikY61mf30S&lt;W]K86enT`_H`Hg&lt;=fbaLQO`c@&lt;hK;Rmmf&gt;KT=]4\mm;NkW]^mcFgV[_]l=8aHk_j]MgIEYV5XJkiW]l^^CKnYn2OgNJ0g&lt;fR\mWo;?JNcFN^cfL_eWZ[Eff[LeWebL[d?YfWFm3O0neW6m3NP3nGQ@G_M?lS61c3KG?`NUXHYTJ?j1SoC7V&gt;RGj_]d[blRO_M^Qg&gt;f_[0oQJWgg`CkhXXJ\hG;1Ujg`4MNjIg_6l3GG;oohYSNBallm3eZnFmebBeaLSDIS17WJfDBN9nUo^n2oC_;Q\;4O3WWk7mAZI17;2]ChHfZeJ;I\fY;^dB\J;NW@cEDj]HE]B8GSiKJgN9M6f4UIKhV02kFjYnXXBH9lF?3gDC&lt;EC`d=4l&lt;aIYa?]YS&lt;9Zl8]AkXcPg:6L69WWX^8R2;YXfC&lt;Xg6AQg@oOoChH=41ln]AG?J3U0Wn&gt;8[8cdWGUnL2Z&gt;Ll4HaNcI&lt;f]SiWCVXSMeP?^a7:Tf&lt;`L3cKdmDl7?Uj&gt;FnPG5NSQBkHE`Yj&gt;ZNQ^;UbDk0kCT]3]YV&lt;50o&lt;2&lt;aTY7THb5hg;3^hl@GYRZE@mbL?5gdHJNW5`6W8[eho^38?;R459L4WN1Jg[egNX[3[_&gt;lAAY&gt;L9Z_H5YN]9:KZMj\cPGZco]??=ig[hH7YShgPS8:44leI:@9R?fLHKlH6UZ]nlAXHFAFUn7AdT=;FK^oZgocoK[2W_=Aj]T;2mBd8`7h`B0K&gt;IP&lt;04@S6]dA9N`8Q8YBk19T@8RFF4T29OB1V7TX7QM01@hI@3`QJ=4@H\nBkS2d5P1BDgN8?4B230Y8lb8ONC@?IPH0A@OMPD?HZ@1`&gt;mj`5N5c60PN06hNI1c8`@k6b0M9IN3`QM68;M1l5Bl&gt;6cX&gt;XD78V@S2j5Ad;C&lt;0cA7OX0nM8&lt;iaN3K0@0Kil664BNSOe:0@R=6NA66f9@PX0d0dHb:LL\6@1aSJl[5h6I38X&lt;0`;0&lt;Al748MXb84H=@Y&lt;lI\5@GNMD;RJd?DeY0Ac1J230g&gt;d1e00LP8d;&gt;V@59CQA1BG&lt;@2[2A45hE8CX:H0A=a\KRAC&lt;Q0YPRb5D&lt;IR63P1QX&lt;JXCS9a3FQ&gt;daQVRjO4I;1da1URZ;LZ444@R2PX2XAXA9Te@FngkoKI_ea&gt;NZN^m\`1H5CMhX9Bn1?ZYS0WAbR2RD8F3W@XajF1=AXS6&lt;TS4i09PN?`gPUG9G3J26`2GbAW]jGY5&lt;AGn^iZAjM_;W5&lt;g^kKMC]B[X13GZm3mmNffKMhb:cJ]DAT&gt;a?_4H8jZX2PIja6[DFTFC:]l]=1AN=PD`VJ&gt;HX2k?Pj7:bQ`W[XWe0\38&lt;V=I\:]2HOl74S6e0a;ZmCFf:3FnRcED67[hUWZPU7ZZKLUVD\PFX_FVE23Q7WUaWV=U&gt;&lt;ZRLQB8LDd0hS94OC1D?6J9N:\\`US2k:iaJY8jY]eTVWO0KLeICMh3dn\dH86aYA7eY]eZZ3=d6WJLE7IPEWIe=_c4FYLEhdA\b5XoJQE;n[HFdKI7C3oK`RFK6l`B8RhhCXhP8XnP3841548PB6P6B[DKHS41JU&lt;Qne:U\ARQ=B[VDHSOT307XA07Qhn2d8RBoajKU&gt;9P@S2lYle3RId0IIf072nP8&gt;;NUah=0ilGD:G5\RN_\=;5jTD@iTfQNGIfmQJ2oJl[SBFC]DLncWBE4mFZe6d_Ob&gt;3YC4APEA@D_mOFNI8ALek79bT&gt;:a8]EjYToY&lt;]8C`FV4Z``X`1aB@L&lt;?V9ARCQ4c:K71jA4o8X@_N2@;?hf9D0M0]D;:A]?]T5@Y1`&gt;Vi=L5H`I25YCYJTF@F?fd@VbI9Pf6?dDZY8JdAcR`QM5&gt;MT&lt;aOnO7&lt;DiRiB;\k?RRIHVCkC&lt;FWi=5fXF\he2n@Q&gt;2TEkZIo6kBK3\C@]3\oE]=7UY8knVi7O5=^_a6d;G^?DaLI=YY]ARAc7NRDMhAYZlK90=KQlem6G@;;lecBDFecfKNA=H&gt;mJl3I59=NFgn`nf[B1:05f5E[`fiTPQ4EDe1H=4ZRWkf3TWlOP&gt;Ela5hZDn]cQJC=UBXIIJdWiR@KZe]DHRbmfI;]VYoi&gt;o?3K1h=6</protected>
@@ -2099,7 +2099,7 @@
 			</Action>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='27'>
-			<NI_LabVIEWParameterResult classname='LabVIEWParameterResult' isroottypedef='true' typecategory='3' timestamp='1628820354' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_LabVIEWParameterResult classname='LabVIEWParameterResult' isroottypedef='true' typecategory='3' timestamp='1650052303' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -2115,7 +2115,7 @@
 			</NI_LabVIEWParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='28'>
-			<VIParameter classname='VIParameter' isroottypedef='true' typecategory='3' timestamp='1628820838' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<VIParameter classname='VIParameter' isroottypedef='true' typecategory='3' timestamp='1650052765' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Label classname='Str'>
 						<value>_notNamed</value>
@@ -2194,7 +2194,7 @@
 			</VIParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='29'>
-			<NI_NodeProperty classname='LVNodeProperty' isroottypedef='true' typecategory='3' timestamp='1628820838' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_NodeProperty classname='LVNodeProperty' isroottypedef='true' typecategory='3' timestamp='1650052765' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<LongName classname='Str'>
 						<value/>
@@ -2215,7 +2215,7 @@
 			</NI_NodeProperty>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='30'>
-			<FlexGStepAdditions classname='FGModule' isroottypedef='true' typecategory='3' timestamp='1628820838' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<FlexGStepAdditions classname='FGModule' isroottypedef='true' typecategory='3' timestamp='1650052765' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<ViCall classname='VICall'>
 						<subprops>
@@ -2423,7 +2423,7 @@
 			</FlexGStepAdditions>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='31'>
-			<VIParameterElement classname='VIParameterElement' isroottypedef='true' typecategory='3' timestamp='1628820838' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<VIParameterElement classname='VIParameterElement' isroottypedef='true' typecategory='3' timestamp='1650052765' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Label classname='Str'>
 						<value>_notNamed</value>
@@ -2493,7 +2493,7 @@
 			</VIParameterElement>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='21'>
-			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
+			<EditSubstep classname='StepType' isroottypedef='true' typecategory='1' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554438' flagsforinstances='4194304' instanceoverrideflags='4194304'>
 				<subprops>
 					<DescriptionFormat typename='Expression' xsi:type='Expression' classname='ExprValue' flagsforinstances='4718616' instanceoverrideflags='4718616' valueflags='4194328' structureflags='524288'>
 						<value>"%ModuleDescription"</value>
@@ -2927,7 +2927,7 @@
 			</EditSubstep>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='22'>
-			<NI_CommonCParameterResult classname='CommonCParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<NI_CommonCParameterResult classname='CommonCParameterResult' isroottypedef='true' typecategory='3' timestamp='1650060499' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Condition typename='Expression' xsi:type='Expression' classname='ExprValue'>
 						<value/>
@@ -2943,7 +2943,7 @@
 			</NI_CommonCParameterResult>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='23'>
-			<FCParameter classname='FCParameter' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<FCParameter classname='FCParameter' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Name classname='Str'>
 						<value>_notNamed</value>
@@ -3031,7 +3031,7 @@
 			</FCParameter>
 		</typedef>
 		<typedef alwayssavetype='false' additionaltypeflags='0' typelistordernum='24'>
-			<FlexCStepAdditions classname='FCModule' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.0.0.49156' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
+			<FlexCStepAdditions classname='FCModule' isroottypedef='true' typecategory='3' timestamp='1650060844' typeversion='21.0.0.49156' typelastmodversion='21.1.0.49154' typeminprodversion='21.0.0.0' typeflags='33554436' valueflags='24'>
 				<subprops>
 					<Call classname='ExternalCall'>
 						<subprops>
@@ -5953,7 +5953,7 @@
 																<value>None</value>
 															</WindowActivation>
 															<ResultOption classname='Num'>
-																<value>1</value>
+																<value>0</value>
 															</ResultOption>
 															<StepFCSeqF classname='Bool'>
 																<value>true</value>
@@ -6995,7 +6995,7 @@
 																<value>None</value>
 															</WindowActivation>
 															<ResultOption classname='Num'>
-																<value>1</value>
+																<value>0</value>
 															</ResultOption>
 															<StepFCSeqF classname='Bool'>
 																<value>true</value>
@@ -7294,7 +7294,7 @@
 																<value>None</value>
 															</WindowActivation>
 															<ResultOption classname='Num'>
-																<value>1</value>
+																<value>0</value>
 															</ResultOption>
 															<StepFCSeqF classname='Bool'>
 																<value>true</value>
@@ -8260,7 +8260,7 @@
 																<value>None</value>
 															</WindowActivation>
 															<ResultOption classname='Num'>
-																<value>1</value>
+																<value>0</value>
 															</ResultOption>
 															<StepFCSeqF classname='Bool'>
 																<value>true</value>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
Disabled result recording for the steps in the Setup and Cleanup blocks of the TestStand example sequence.

### Why should this Pull Request be merged?
To fix [Bug 2397391](https://dev.azure.com/ni/DevCentral/_workitems/edit/2397391): LV/Python example TestStand sequence setup/cleanup steps no longer disable result recording

### What testing has been done?
Manually verified that the bug is resolved and the TestStand sequence is working as expected.