### PR TITLE
Change the build spec to require grpc-labview 1.0.0.1

### DIFF
--- a/Source/Build Specs/MeasurementLink Generator.vipb
+++ b/Source/Build Specs/MeasurementLink Generator.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-09-01 11:51:23" Creator="lvadmin" Comments="" ID="cfe8d93cce5d786b1b8b66a430bbf5b1">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-09-21 08:25:48" Creator="lvadmin" Comments="" ID="6be6937a6b9faa60ddd55b006df293f6">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Generator</Package_File_Name>
     <Library_Version>1.2.0.4</Library_Version>
@@ -17,7 +17,7 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.7</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library =1.0.0.1</Additional_External_Dependencies>
       <Additional_External_Dependencies>ni_measurementlink_service &gt;=1.1.0.2</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>

--- a/Source/Build Specs/MeasurementLink Service.vipb
+++ b/Source/Build Specs/MeasurementLink Service.vipb
@@ -1,4 +1,4 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-09-01 11:45:25" Creator="lvadmin" Comments="" ID="25f9f84282272e971012393e81b911a9">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2023-09-21 08:25:14" Creator="lvadmin" Comments="" ID="f6cb6d37f0e61000cbdedcde6483bcd8">
   <Library_General_Settings>
     <Package_File_Name>NI_MeasurementLink_Service</Package_File_Name>
     <Library_Version>1.2.0.4</Library_Version>
@@ -17,8 +17,8 @@
   </Library_General_Settings>
   <Advanced_Settings>
     <Package_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_library &gt;=1.0.0.7</Additional_External_Dependencies>
-      <Additional_External_Dependencies>ni_lib_labview_grpc_servicer &gt;=1.0.0.7</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_library =1.0.0.1</Additional_External_Dependencies>
+      <Additional_External_Dependencies>ni_lib_labview_grpc_servicer =1.0.0.1</Additional_External_Dependencies>
     </Package_Dependencies>
     <Custom_Action_VIs>
       <Pre-Build_VI/>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

We only support grpc-labview 1.0.0.1. This PR makes that dependency official