### PR TITLE
Update .proto files in LabVIEW repo

### DIFF
--- a/Source/Protos/ni/measurementlink/measurement/v2/measurement_service.proto
+++ b/Source/Protos/ni/measurementlink/measurement/v2/measurement_service.proto
@@ -109,6 +109,8 @@ message ConfigurationParameter {
   int32 field_number = 1;
 
   // Required. The data type for the configuration parameter.
+  // NOTE: If this is Kind.TypeMessage, you *must* also fill in
+  // the 'message_type' field below with the gRPC full name of the message.
   google.protobuf.Field.Kind type = 2;
 
   // Required. The name of the configuration parameter. When defining a user interface for the measurement, a control
@@ -133,6 +135,10 @@ message ConfigurationParameter {
   //   - Expected format: JSON dictionary string"
   //   - Example: "{\"RED\":0, \"GREEN\":25, \"BLUE\":5}"
   map<string, string> annotations = 5;
+  
+  // Required when 'type' is Kind.TypeMessage. Ignored for any other 'type'.
+  // This is the gRPC full name of the message type.
+  string message_type = 6;
 }
 
 // Message that defines an output of the measurement.
@@ -142,6 +148,8 @@ message Output {
   int32 field_number = 1;
 
   // Required. The data type for the output.
+  // NOTE: If this is Kind.TypeMessage, you *must* also fill in
+  // the 'message_type' field below with the gRPC full name of the message.
   google.protobuf.Field.Kind type = 2;
 
   // Required. The name of the output. When defining a user interface for the measurement, an indicator
@@ -154,4 +162,8 @@ message Output {
   // Optional. Represents a set of annotations on the type.
   // See documentation for ConfigurationParameter annotations for more details and examples.
   map<string, string> annotations = 5;
+
+  // Required when 'type' is Kind.TypeMessage. Ignored for any other 'type'.
+  // This is the gRPC full name of the message type.
+  string message_type = 6;
 }

--- a/Source/Protos/ni/protobuf/types/xydata.proto
+++ b/Source/Protos/ni/protobuf/types/xydata.proto
@@ -1,0 +1,28 @@
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+syntax = "proto3";
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+package ni.protobuf.types;
+
+//---------------------------------------------------------------------
+//---------------------------------------------------------------------
+option csharp_namespace = "NationalInstruments.Protobuf.Types";
+option go_package = "types";
+option java_multiple_files = true;
+option java_outer_classname = "XYDataProto";
+option java_package = "com.ni.protobuf.types";
+option objc_class_prefix = "NIPT";
+option php_namespace = "NI\\PROTOBUF\\TYPES";
+option ruby_package = "NI::Protobuf::Types";
+
+// XYData for a cartesian graph.
+// x_data and y_data should contain the same number of values.
+// If they do not, the smaller-sized array will be used to determine
+// the number of XY points.
+message DoubleXYData
+{
+    repeated double x_data = 1;
+    repeated double y_data = 2;
+}


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

@aepete pointed out that our measurement_service.proto file is behind the original one. In addition, xydata.proto has been added. I see no reason not to update these now, even if they won't take effect until we regenerate our libraries with grpc-labview.

Another option would be to defer adding these until the same PR where we're updating the generated libraries. I could see how someone would get the impression that our libraries would match the submitted protos.

### Why should this Pull Request be merged?

Keep our .proto definitions up-to-date.

### What testing has been done?

None. I expect no effects of this for now.