### PR TITLE
Add new destination folder and change build.

### DIFF
--- a/Source/Example Measurements/NI-FGEN Standard Function/NIFgenStandardFunction.lvproj
+++ b/Source/Example Measurements/NI-FGEN Standard Function/NIFgenStandardFunction.lvproj
@@ -89,7 +89,7 @@
 				<Property Name="Bld_modifyLibraryFile" Type="Bool">true</Property>
 				<Property Name="Bld_postActionVIID" Type="Ref">/My Computer/NIFgenStandardFunction.lvlib/Advanced/Build Assets/Post-Build Action.vi</Property>
 				<Property Name="Bld_previewCacheID" Type="Str">{0C374A6C-64A6-436A-949A-D35936AD611B}</Property>
-				<Property Name="Bld_version.build" Type="Int">3</Property>
+				<Property Name="Bld_version.build" Type="Int">4</Property>
 				<Property Name="Bld_version.major" Type="Int">1</Property>
 				<Property Name="Destination[0].destName" Type="Str">NIFgenStandardFunction.exe</Property>
 				<Property Name="Destination[0].path" Type="Path">../builds/NI_AB_PROJECTNAME/NIFgenStandardFunction/NIFgenStandardFunction.exe</Property>
@@ -97,8 +97,10 @@
 				<Property Name="Destination[0].type" Type="Str">App</Property>
 				<Property Name="Destination[1].destName" Type="Str">Support Directory</Property>
 				<Property Name="Destination[1].path" Type="Path">../builds/NI_AB_PROJECTNAME/NIFgenStandardFunction/data</Property>
-				<Property Name="DestinationCount" Type="Int">2</Property>
-				<Property Name="Source[0].itemID" Type="Str">{88A95EB8-C8E6-4EAB-BBF0-9D8655D770DD}</Property>
+				<Property Name="Destination[2].destName" Type="Str">Controls</Property>
+				<Property Name="Destination[2].path" Type="Path">../builds/NI_AB_PROJECTNAME/NIFgenStandardFunction</Property>
+				<Property Name="DestinationCount" Type="Int">3</Property>
+				<Property Name="Source[0].itemID" Type="Str">{F8734861-575B-4961-8703-0723E0E8AACC}</Property>
 				<Property Name="Source[0].type" Type="Str">Container</Property>
 				<Property Name="Source[1].destinationIndex" Type="Int">0</Property>
 				<Property Name="Source[1].itemID" Type="Ref">/My Computer/NIFgenStandardFunction.lvlib/Get Measurement Details.vi</Property>
@@ -135,7 +137,7 @@
 				<Property Name="Source[8].itemID" Type="Ref">/My Computer/NIFgenStandardFunction.lvlib/subVIs/Wait Until Generation Complete.vi</Property>
 				<Property Name="Source[8].sourceInclusion" Type="Str">Include</Property>
 				<Property Name="Source[8].type" Type="Str">VI</Property>
-				<Property Name="Source[9].destinationIndex" Type="Int">1</Property>
+				<Property Name="Source[9].destinationIndex" Type="Int">2</Property>
 				<Property Name="Source[9].itemID" Type="Ref">/My Computer/NIFgenStandardFunction.lvlib/Waveform.ctl</Property>
 				<Property Name="Source[9].type" Type="Str">VI</Property>
 				<Property Name="SourceCount" Type="Int">10</Property>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds a new destination Folder "Controls" and moves the Waveform.ctl to main Folder instead of using the Support Directory "Data" 

### Why should this Pull Request be merged?

With this change we avoid Labview to be looking for control when opening the InstrumentStudio. This is only observe for a brief moment on slow machines. 
We also avoid adding the Data folder on the Build. 

### What testing has been done?

Rerun example
Rerun the sequence for TestStand

![image](https://github.com/ni/measurementlink-labview/assets/111389775/e7edf6ac-c5c8-462f-930b-8f7318f28023)
![image](https://github.com/ni/measurementlink-labview/assets/111389775/cd18f1f0-325b-4e48-87ae-fb240d35fcaa)


