### PR TITLE
Passed LABVIEW_PATH as command line argument in run_tests.py

### DIFF
--- a/Source/Tests/run_tests.py
+++ b/Source/Tests/run_tests.py
@@ -1,4 +1,5 @@
 
+import argparse
 import logging
 import os
 import subprocess
@@ -12,15 +13,19 @@ handler.setLevel(logging.DEBUG)
 _logger.addHandler(handler)
 
 def main():
-    return_code = run_all_tests()
+    labview_path = _parse_command_line_args()
+    return_code = run_all_tests(labview_path)
     sys.exit(return_code)
 
 
-def run_all_tests():
+def run_all_tests(labview_path: str):
     test_directory = os.path.abspath(os.path.dirname(__file__))
     test_runner_vi = os.path.join(test_directory , "run_tests.vi")
     _logger.debug(f"Launching {test_runner_vi}.")
-    test_result = subprocess.run(["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", os.path.normpath(test_runner_vi)], capture_output= True)
+    kwargs = ["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", os.path.normpath(test_runner_vi)]
+    if labview_path:
+        kwargs.extend(["-LabVIEWPath", labview_path])
+    test_result = subprocess.run(kwargs, capture_output= True)
     
     formatted_stdout = test_result.stdout.decode().replace('\r\n','\n').strip()
     _logger.debug(formatted_stdout)
@@ -29,6 +34,14 @@ def run_all_tests():
         _logger.error(formatted_stderr)
 
     return test_result.returncode
+
+
+def _parse_command_line_args():
+    parser = argparse.ArgumentParser(description="Run LabVIEW tests using LabVIEWCLI")
+    parser.add_argument("labview_path", type=str, help="Path to the LabVIEW executable", nargs='?', default=None)
+
+    args = parser.parse_args()
+    return args.labview_path
 
 
 main()


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- To implement **[Technical Debt 2350468](https://dev.azure.com/ni/DevCentral/_workitems/edit/2350468): Redundant / externally-maintained test runners**, we have planned to use self-hosted runner which runs tests in multiple LabVIEW versions(2020, 2021, 2022).
- Currently `run_tests.py` doesn't pass `LABVIEW_PATH` to the `LABVIEW_CLI`, so the last used LABVIEW version is used for running tests.
https://github.com/ni/measurementlink-labview/actions/runs/6699125262/job/18202656739#step:4:13
- So to make `run_tests.py` script to be compatible for running any LABVIEW version, I have made the following changes
    - Used `argparse` to add an optional command line argument `labview_path` with default value `None`.
    - Used a list `kwargs` that defines LABVIEWCLI command and additionally `LABVIEW_PATH` if `labview_path` is not `None`.

### Why should this Pull Request be merged?
Helps in using `run_tests.py` for multiple LabVIEW versions.

### What testing has been done?
Manually tested the commands
- `python run_tests.py "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe"` - launched specified LabVIEW 2020 version.
```
PS measurementlink-labview\Source\Tests> python run_tests.py "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe"
Launching D:\TAF\measurementlink-labview\Source\Tests\run_tests.vi.
LabVIEWCLI started logging in file:  C:\Users\battu.mounika\AppData\Local\Temp\lvtemporary_478756.log
Using LabVIEW: "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe"
LabVIEW launched successfully.
```
- `python run_tests.py` - launched last used LabVIEW version. 
```
PS measurementlink-labview\Source\Tests> python run_tests.py
Launching D:\TAF\measurementlink-labview\Source\Tests\run_tests.vi.
LabVIEWCLI started logging in file:  C:\Users\battu.mounika\AppData\Local\Temp\lvtemporary_962638.log
"LabVIEWPath" command line argument is not passed. Using last used LabVIEW: "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe"
LabVIEW launched successfully.
```