### PR TITLE
Remove skipped test that doesn't exist anymore

### DIFF
--- a/Source/Tests/skip_tests.lst
+++ b/Source/Tests/skip_tests.lst
@@ -1,2 +1,1 @@
 test_DefaultTemplateMeasurement_GetUiDetails_CorrectUiPathUrl.vi
-test_ServiceLocationPool_DiscoveryServiceUnavailable_GetUncachedLocation_ReturnsError.vi


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

[AB#2544464](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/2544464)
#320 

The failing test doesn't even exist anymore. That code was refactored and the new tests don't call into any services and therefore can't fail for the same reason.

### What testing has been done?

PR tests