### PR TITLE
Include Port number in LabVIEWCLI in run_tests.py

### DIFF
--- a/Source/Tests/run_tests.py
+++ b/Source/Tests/run_tests.py
@@ -13,18 +13,18 @@ handler.setLevel(logging.DEBUG)
 _logger.addHandler(handler)
 
 def main():
-    labview_path = _parse_command_line_args()
-    return_code = run_all_tests(labview_path)
+    labview_path, port_number = _parse_command_line_args()
+    return_code = run_all_tests(labview_path, port_number)
     sys.exit(return_code)
 
 
-def run_all_tests(labview_path: str):
+def run_all_tests(labview_path: str, port_number: str):
     test_directory = os.path.abspath(os.path.dirname(__file__))
     test_runner_vi = os.path.join(test_directory , "run_tests.vi")
     _logger.debug(f"Launching {test_runner_vi}.")
     kwargs = ["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", os.path.normpath(test_runner_vi)]
     if labview_path:
-        kwargs.extend(["-LabVIEWPath", labview_path])
+        kwargs.extend(["-LabVIEWPath", labview_path, "-PortNumber", port_number])
     test_result = subprocess.run(kwargs, capture_output= True)
     
     formatted_stdout = test_result.stdout.decode().replace('\r\n','\n').strip()
@@ -38,10 +38,11 @@ def run_all_tests(labview_path: str):
 
 def _parse_command_line_args():
     parser = argparse.ArgumentParser(description="Run LabVIEW tests using LabVIEWCLI")
-    parser.add_argument("labview_path", type=str, help="Path to the LabVIEW executable", nargs='?', default=None)
+    parser.add_argument("--labview_path", type=str, help="Path to the LabVIEW executable", nargs='?', default=None)
+    parser.add_argument("--port_number", type=str, help="TCP/IP port number of LabVIEW executable", nargs='?', default="3363")
 
     args = parser.parse_args()
-    return args.labview_path
+    return args.labview_path, args.port_number
 
 
 main()

--- a/Source/Tests/run_tests.py
+++ b/Source/Tests/run_tests.py
@@ -18,13 +18,13 @@ def main():
     sys.exit(return_code)
 
 
-def run_all_tests(labview_path: str, port_number: str):
+def run_all_tests(labview_path: str, port_number: int):
     test_directory = os.path.abspath(os.path.dirname(__file__))
     test_runner_vi = os.path.join(test_directory , "run_tests.vi")
     _logger.debug(f"Launching {test_runner_vi}.")
-    kwargs = ["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", os.path.normpath(test_runner_vi)]
+    kwargs = ["LabVIEWCLI", "-OperationName", "RunVI", "-VIPath", os.path.normpath(test_runner_vi), "-PortNumber", str(port_number)]
     if labview_path:
-        kwargs.extend(["-LabVIEWPath", labview_path, "-PortNumber", port_number])
+        kwargs.extend(["-LabVIEWPath", labview_path])
     test_result = subprocess.run(kwargs, capture_output= True)
     
     formatted_stdout = test_result.stdout.decode().replace('\r\n','\n').strip()
@@ -38,8 +38,8 @@ def run_all_tests(labview_path: str, port_number: str):
 
 def _parse_command_line_args():
     parser = argparse.ArgumentParser(description="Run LabVIEW tests using LabVIEWCLI")
-    parser.add_argument("--labview_path", type=str, help="Path to the LabVIEW executable", nargs='?', default=None)
-    parser.add_argument("--port_number", type=str, help="TCP/IP port number of LabVIEW executable", nargs='?', default="3363")
+    parser.add_argument("--labview-path", type=str, help="Path to the LabVIEW executable", nargs='?', default=None)
+    parser.add_argument("--port-number", type=int, help="TCP/IP port number of LabVIEW executable", nargs='?', default=3363)
 
     args = parser.parse_args()
     return args.labview_path, args.port_number


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?
- Currently in `run_tests.py`, `LabVIEWCLI` has `-OperationName` (required) and `-LabVIEWPath` {optional) arguments.
- For working with multiple LabVIEW versions with unique TCP/IP Port numbers, `LabVIEWCLI` requires yet another argument `-PortNumber` to communicate with LabVIEW.
- Thus, added  optional argument `--port_number` and passed the same to the `LabVIEWCLI` with default value `3363`.

### Why should this Pull Request be merged?
measlinkbot labview runner requires this change to run tests in multiple LabVIEW versions.

### What testing has been done?
Ran the following command and ensured connection is established with LabVIEW.
```
PS D:\measurementlink-labview\Source\Tests> python run_tests.py --labview_path "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe" --port_number "3365"
Launching D:\measurementlink-labview\Source\Tests\run_tests.vi.
LabVIEWCLI started logging in file:  C:\Users\battu.mounika\AppData\Local\Temp\lvtemporary_96279.log
Using LabVIEW: "C:\Program Files\National Instruments\LabVIEW 2020\LabVIEW.exe"
LabVIEW launched successfully.
Connection established with LabVIEW at port number 3365.
```