### PR TITLE
CONTRIBUTING.md: Update required VIPM version to 2023 for building packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ The source code is built into two LabVIEW packages
 To build the packages:
 
 1. Open the desired VIPM specification file (.vipb) under the [`Build Specs`](https://github.com/ni/measurementlink-labview/tree/main/Source/Build%20Specs) folder
-2. Open the Specification file using VIPM 2020
+2. Open the Specification file using VIPM 2023
 3. Click Build - A .vip will be created in the `Build Output` folder under the repo root directory
 
 ## `ni_measurementlink_service` Package

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ The source code is built into two LabVIEW packages
 To build the packages:
 
 1. Open the desired VIPM specification file (.vipb) under the [`Build Specs`](https://github.com/ni/measurementlink-labview/tree/main/Source/Build%20Specs) folder
-2. Open the Specification file using VIPM 2023
+2. Open the Specification file using VIPM 2023 or later
 3. Click Build - A .vip will be created in the `Build Output` folder under the repo root directory
 
 ## `ni_measurementlink_service` Package


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the VIPM version in CONTRIBUTING.md to 2023 because this version is now required to build the packages.

I didn't update README.md because VIPM 2023 is not required to install the packages.

### Why should this Pull Request be merged?

Improve onboarding docs.

### What testing has been done?

N/A