### PR TITLE
examples: Fix lvlib references to old TestStand VI names

### DIFF
--- a/Source/Example Measurements/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement.lvproj
+++ b/Source/Example Measurements/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement.lvproj
@@ -25,7 +25,6 @@
 				<Item Name="Application Directory.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/file.llb/Application Directory.vi"/>
 				<Item Name="Check if File or Folder Exists.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/libraryn.llb/Check if File or Folder Exists.vi"/>
 				<Item Name="Clear Errors.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Clear Errors.vi"/>
-				<Item Name="ConfigurationParameter_AnnotationsEntry.ctl" Type="VI" URL="/&lt;vilib&gt;/MeasurementLink/MeasurementLink Measurement Server/Helpers/typeDefs/ConfigurationParameter_AnnotationsEntry.ctl"/>
 				<Item Name="Equal Comparable.lvclass" Type="LVClass" URL="/&lt;vilib&gt;/Comparison/Equal/Equal Comparable/Equal Comparable.lvclass"/>
 				<Item Name="Equal Functor.lvclass" Type="LVClass" URL="/&lt;vilib&gt;/Comparison/Equal/Equal Functor/Equal Functor.lvclass"/>
 				<Item Name="Equals.vim" Type="VI" URL="/&lt;vilib&gt;/Comparison/Equals.vim"/>
@@ -50,7 +49,6 @@
 				<Item Name="NI_FileType.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/lvfile.llb/NI_FileType.lvlib"/>
 				<Item Name="NI_LVConfig.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/config.llb/NI_LVConfig.lvlib"/>
 				<Item Name="NI_PackedLibraryUtility.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/LVLibp/NI_PackedLibraryUtility.lvlib"/>
-				<Item Name="Output.ctl" Type="VI" URL="/&lt;vilib&gt;/MeasurementLink/MeasurementLink Measurement Server/Helpers/typeDefs/Output.ctl"/>
 				<Item Name="Remove Duplicates From 1D Array.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Remove Duplicates From 1D Array.vim"/>
 				<Item Name="Search Unsorted 1D Array Core.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Helpers/Search Unsorted 1D Array Core.vim"/>
 				<Item Name="Search Unsorted 1D Array.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Search Unsorted 1D Array.vim"/>

--- a/Source/Example Measurements/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement.lvlib
+++ b/Source/Example Measurements/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement/Keysight 34401A DMM Measurement.lvlib
@@ -21,8 +21,8 @@
 		<Item Name="Wait Until Canceled.vi" Type="VI" URL="../subVIs/Wait Until Canceled.vi"/>
 	</Item>
 	<Item Name="TestStand Code Modules" Type="Folder">
-		<Item Name="Create and Register Sessions.vi" Type="VI" URL="../TestStand Code Modules/Create and Register Sessions.vi"/>
-		<Item Name="Unregister and Destroy Sessions.vi" Type="VI" URL="../TestStand Code Modules/Unregister and Destroy Sessions.vi"/>
+		<Item Name="Initialize and Register Sessions.vi" Type="VI" URL="../TestStand Code Modules/Initialize and Register Sessions.vi"/>
+		<Item Name="Unregister and Close Sessions.vi" Type="VI" URL="../TestStand Code Modules/Unregister and Close Sessions.vi"/>
 		<Item Name="Update Pin Map.vi" Type="VI" URL="../TestStand Code Modules/Update Pin Map.vi"/>
 	</Item>
 	<Item Name="Get Measurement Details.vi" Type="VI" URL="../Get Measurement Details.vi"/>

--- a/Source/Example Measurements/NI-SCOPE Acquire Waveform/NI-SCOPE Acquire Waveform/NIScopeAcquireWaveform.lvlib
+++ b/Source/Example Measurements/NI-SCOPE Acquire Waveform/NI-SCOPE Acquire Waveform/NIScopeAcquireWaveform.lvlib
@@ -14,8 +14,8 @@
 		<Item Name="MeasurementPlugin.lvclass" Type="LVClass" URL="../Advanced/MeasurementPlugin.lvclass"/>
 	</Item>
 	<Item Name="TestStand Code Modules" Type="Folder">
-		<Item Name="Create and Register Sessions.vi" Type="VI" URL="../TestStand Code Modules/Create and Register Sessions.vi"/>
-		<Item Name="Unregister and Destroy Sessions.vi" Type="VI" URL="../TestStand Code Modules/Unregister and Destroy Sessions.vi"/>
+		<Item Name="Initialize and Register Sessions.vi" Type="VI" URL="../TestStand Code Modules/Initialize and Register Sessions.vi"/>
+		<Item Name="Unregister and Close Sessions.vi" Type="VI" URL="../TestStand Code Modules/Unregister and Close Sessions.vi"/>
 		<Item Name="Update Pin Map.vi" Type="VI" URL="../TestStand Code Modules/Update Pin Map.vi"/>
 	</Item>
 	<Item Name="Get Measurement Details.vi" Type="VI" URL="../Get Measurement Details.vi"/>

--- a/Source/Example Measurements/NI-SCOPE Acquire Waveform/NIScopeAcquireWaveform.lvproj
+++ b/Source/Example Measurements/NI-SCOPE Acquire Waveform/NIScopeAcquireWaveform.lvproj
@@ -74,7 +74,6 @@
 				<Item Name="Application Directory.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/file.llb/Application Directory.vi"/>
 				<Item Name="Check if File or Folder Exists.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/libraryn.llb/Check if File or Folder Exists.vi"/>
 				<Item Name="Clear Errors.vi" Type="VI" URL="/&lt;vilib&gt;/Utility/error.llb/Clear Errors.vi"/>
-				<Item Name="ConfigurationParameter_AnnotationsEntry.ctl" Type="VI" URL="/&lt;vilib&gt;/MeasurementLink/MeasurementLink Measurement Server/Helpers/typeDefs/ConfigurationParameter_AnnotationsEntry.ctl"/>
 				<Item Name="Equal Comparable.lvclass" Type="LVClass" URL="/&lt;vilib&gt;/Comparison/Equal/Equal Comparable/Equal Comparable.lvclass"/>
 				<Item Name="Equal Functor.lvclass" Type="LVClass" URL="/&lt;vilib&gt;/Comparison/Equal/Equal Functor/Equal Functor.lvclass"/>
 				<Item Name="Equals.vim" Type="VI" URL="/&lt;vilib&gt;/Comparison/Equals.vim"/>
@@ -100,7 +99,6 @@
 				<Item Name="NI_FileType.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/lvfile.llb/NI_FileType.lvlib"/>
 				<Item Name="NI_LVConfig.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/config.llb/NI_LVConfig.lvlib"/>
 				<Item Name="NI_PackedLibraryUtility.lvlib" Type="Library" URL="/&lt;vilib&gt;/Utility/LVLibp/NI_PackedLibraryUtility.lvlib"/>
-				<Item Name="Output.ctl" Type="VI" URL="/&lt;vilib&gt;/MeasurementLink/MeasurementLink Measurement Server/Helpers/typeDefs/Output.ctl"/>
 				<Item Name="Remove Duplicates From 1D Array.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Remove Duplicates From 1D Array.vim"/>
 				<Item Name="Search Unsorted 1D Array Core.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Helpers/Search Unsorted 1D Array Core.vim"/>
 				<Item Name="Search Unsorted 1D Array.vim" Type="VI" URL="/&lt;vilib&gt;/Array/Search Unsorted 1D Array.vim"/>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Update the 34401A and NI-SCOPE example lvlibs to reference the new TestStand VI names and resave project files.

### Why should this Pull Request be merged?

Enable building examples

Enable running examples with TestStand

### What testing has been done?

Manually tested both examples.
- 34401A works in InstrumentStudio and TestStand
- NI-SCOPE fails with "An error occurred while creating the measurement client" in InstrumentStudio and TestStand