### PR TITLE
Update Keysight doc and delete UIProgressUpdates

### DIFF
--- a/Source/Example Measurements/Keysight 34401A DMM Measurement/README.md
+++ b/Source/Example Measurements/Keysight 34401A DMM Measurement/README.md
@@ -23,8 +23,9 @@ HP/Agilent/Keysight 34401A DMM.
 
 ### Required Driver Software
 
+- LabVIEW 2021 or later
 - NI-488.2 and/or NI-Serial
-- NI-VISA
+- NI-VISA 2024 Q1 or later
 - [Agilent 34401 LabVIEW Plug-and-Play (project style) Instrument Driver](https://sine.ni.com/apps/utf8/niid_web_display.download_page?p_id_guid=014E7F05D12C6F8BE0440003BA7CCD71)
 
 ### Required Hardware

--- a/Source/Example Measurements/README.md
+++ b/Source/Example Measurements/README.md
@@ -15,7 +15,7 @@ HP/Agilent/Keysight 34401A DMM.
 - `NI-FGEN Standard Function`: Generates a waveform using standard function mode
   with an NI FGEN.
 - `NI-SCOPE Acquire Waveform`: Acquires waveforms from an NI SCOPE.
-- `VISA Measurement`: Writes and reads a value from a serial instrument using VISA.
+- `VISA Measurement` : Writes and reads a value from a serial instrument using VISA.
 
 For more details about a specific example, see the `README.md` file included
 with the example.

--- a/Source/Example Measurements/README.md
+++ b/Source/Example Measurements/README.md
@@ -16,8 +16,6 @@ HP/Agilent/Keysight 34401A DMM.
   with an NI FGEN.
 - `NI-SCOPE Acquire Waveform`: Acquires waveforms from an NI SCOPE.
 - `VISA Measurement`: Writes and reads a value from a serial instrument using VISA.
-- `UIProgressUpdates`: Generates random numbers and updates the measurement UI
-  to show progress.
 
 For more details about a specific example, see the `README.md` file included
 with the example.

--- a/Source/Example Measurements/README.md
+++ b/Source/Example Measurements/README.md
@@ -15,7 +15,7 @@ HP/Agilent/Keysight 34401A DMM.
 - `NI-FGEN Standard Function`: Generates a waveform using standard function mode
   with an NI FGEN.
 - `NI-SCOPE Acquire Waveform`: Acquires waveforms from an NI SCOPE.
-- `VISA Measurement` : Writes and reads a value from a serial instrument using VISA.
+- `VISA Measurement`: Writes and reads a value from a serial instrument using VISA.
 
 For more details about a specific example, see the `README.md` file included
 with the example.


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Modify the list of required software for the Keysight example to include VISA 2024 Q1 or later and LabVIEW 2021 or later. 
- Also remove mention of the UIProgressUpdates example.