### PR TITLE
Run VI Analyzer checks as part of CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,9 @@ jobs:
     name: Run LabVIEW Tests
     if: ${{ github.repository == 'ni/measurementlink-labview' || github.event.pull_request.head.repo.full_name == 'ni/measurementlink-labview' }}
     uses: ./.github/workflows/run_g_tests.yml
+
+  run_vi_analyzer:
+    name: Run VI Analyzer
+    if: ${{ github.repository == 'ni/measurementlink-labview' || github.event.pull_request.head.repo.full_name == 'ni/measurementlink-labview' }}
+    uses: ./.github/workflows/run_vi_analyzer.yml
+


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_
- [ ] **(n/a)** <!--G_DIFF_CHECK--> Automatically post PR comments with images for G code changes? _(Recommended for small changes)_

### What does this Pull Request accomplish?

Run VI Analyzer checks as part of CI workflow

### Why should this Pull Request be merged?

- Running all validation in the CI is generally good practice
- Our Broken VI check now runs as part of VI Analyzer (no longer runs as a G test), so this update ensures continuity of the Broken VI check running in the CI

### What testing has been done?

VI Analyzer check passes in local run & PR workflow