### PR TITLE
Add `Unused Code` check to VI Analyzer workflow

### DIFF
--- a/Source/Tools/PR.viancfg
+++ b/Source/Tools/PR.viancfg
@@ -1058,5 +1058,21 @@
 	</Test>
 </TestConfigData>
 <ExclusionData>
+	<Item>
+		<Path>"..\\Runtime\\MeasurementLink Session Management Client\\RPC Messages"</Path>
+		<ExcludedTests>"Unused Code"</ExcludedTests>
+	</Item>
+	<Item>
+		<Path>"..\\Runtime\\MeasurementLink Measurement Service Base V2\\RPC Messages"</Path>
+		<ExcludedTests>"Unused Code"</ExcludedTests>
+	</Item>
+	<Item>
+		<Path>"..\\Runtime\\MeasurementLink Measurement Server Internal\\RPC Messages"</Path>
+		<ExcludedTests>"Unused Code"</ExcludedTests>
+	</Item>
+	<Item>
+		<Path>"..\\Runtime\\MeasurementLink Discovery Client\\RPC Messages"</Path>
+		<ExcludedTests>"Unused Code"</ExcludedTests>
+	</Item>
 </ExclusionData>
 </Config>

--- a/Source/Tools/PR.viancfg
+++ b/Source/Tools/PR.viancfg
@@ -257,7 +257,7 @@
 		<MaxFailures>5</MaxFailures>
 		<BasePath>"LabVIEW"</BasePath>
 		<RelativePath>"project\\_VI Analyzer\\_tests\\Block Diagram\\Style\\Unused Code.llb"</RelativePath>
-		<Selected>FALSE</Selected>
+		<Selected>TRUE</Selected>
 		<Controls>
 		</Controls>
 	</Test>


### PR DESCRIPTION
<!-- TODO: Mark the following with an 'x' as applicable -->
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_
- [ ] **(n/a)** <!--G_DIFF_CHECK--> Automatically post PR comments with images for G code changes? _(Recommended for small changes)_

### What does this Pull Request accomplish?

Adds `Unused Code` check to the VI Analyzer workflow.

### Why should this Pull Request be merged?

`Unused Code` is considered a ranking-2 (high-severity) check in VIAnalyzer by default, as having unused code risks performance issues and is exemplary of poor programming practice.

Note: Enabling this `Unused Code` check revealed that [certain subVIs proto-generated by grpc-labview are subject to fail the check](https://github.com/ni/grpc-labview/issues/333).  To work around this, several exclusions have been added to the VI Analyzer configuration file.

### What testing has been done?

VI Analyzer tests pass locally and in PR workflow