### PR TITLE
Bump versions for VI packages to 3.5.2.2 for patch release

### DIFF
--- a/Source/Build Specs/Measurement Plug-In SDK Examples.vipb
+++ b/Source/Build Specs/Measurement Plug-In SDK Examples.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2024-03-06 15:30:02" Modified_Date="2026-02-09 09:27:13" Creator="ksreekan" Comments="" ID="7988914ae9df274c5e5bfcb782086050">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2024-03-06 15:30:02" Modified_Date="2026-03-10 10:40:44" Creator="ksreekan" Comments="" ID="bacb7f923335b2f4cff9c1aa57cfba08">
   <Library_General_Settings>
     <Package_File_Name>ni_measurement_plugin_sdk_examples</Package_File_Name>
-    <Library_Version>3.5.2.1</Library_Version>
+    <Library_Version>3.5.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..\Example Measurements</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>

--- a/Source/Build Specs/Measurement Plug-In SDK Generator.vipb
+++ b/Source/Build Specs/Measurement Plug-In SDK Generator.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2026-02-09 09:27:32" Creator="lvadmin" Comments="" ID="a0aa071a60224081034422201a73947f">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2026-03-10 10:39:24" Creator="lvadmin" Comments="" ID="0006956ac44bd8a498b80ea114becd66">
   <Library_General_Settings>
     <Package_File_Name>ni_measurement_plugin_sdk_generator</Package_File_Name>
-    <Library_Version>3.5.2.1</Library_Version>
+    <Library_Version>3.5.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>

--- a/Source/Build Specs/Measurement Plug-In SDK Service.vipb
+++ b/Source/Build Specs/Measurement Plug-In SDK Service.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2026-02-09 09:27:52" Creator="lvadmin" Comments="" ID="4228a88cb54f4286bfdf9ba30194cea5">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2023-01-23 14:05:21" Modified_Date="2026-03-10 10:38:52" Creator="lvadmin" Comments="" ID="bcaddfeabbffc7e7498aee410cafd162">
   <Library_General_Settings>
     <Package_File_Name>ni_measurement_plugin_sdk_service</Package_File_Name>
-    <Library_Version>3.5.2.1</Library_Version>
+    <Library_Version>3.5.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>

--- a/Source/Build Specs/Measurement Plug-In SDK.vipb
+++ b/Source/Build Specs/Measurement Plug-In SDK.vipb
@@ -1,7 +1,7 @@
-<VI_Package_Builder_Settings Version="2020.1" Created_Date="2024-03-06 15:09:40" Modified_Date="2026-02-09 09:28:11" Creator="ksreekan" Comments="" ID="78a458d73c16b483ef62749dcd23c814">
+<VI_Package_Builder_Settings Version="2020.1" Created_Date="2024-03-06 15:09:40" Modified_Date="2026-03-10 10:41:06" Creator="ksreekan" Comments="" ID="c279b939ea049a6458eb492d837136fc">
   <Library_General_Settings>
     <Package_File_Name>ni_measurement_plugin_sdk</Package_File_Name>
-    <Library_Version>3.5.2.1</Library_Version>
+    <Library_Version>3.5.2.2</Library_Version>
     <Auto_Increment_Version>false</Auto_Increment_Version>
     <Library_Source_Folder>..</Library_Source_Folder>
     <Library_Output_Folder>..\..\Build Output</Library_Output_Folder>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/measurement-services-labview/blob/main/CONTRIBUTING.md). _(Required)_

### What does this Pull Request accomplish?

Bumps versions in releases/3.5 to 3.5.2.2.

### Why should this Pull Request be merged?

Imminent patch release to fix a problem with the built packages from 3.4.0.1 to 3.5.2.1.

See #664 

### What testing has been done?

None. Version bump only.